### PR TITLE
Added check for com port length to prevent drop down disapperance

### DIFF
--- a/src/main_window/renderer.js
+++ b/src/main_window/renderer.js
@@ -48,6 +48,7 @@ var sequenceTimeout;
 var sequence_pos = 0;
 const find_container = document.getElementById("find_container");
 var find_box = null;
+var port_count = 0;
 
 // config UI of find interface
 let findInPage = new FindInPage(remote.getCurrentWebContents(), {
@@ -257,12 +258,16 @@ function changeTimestamp() {
 
 function getPorts() {
     SerialPort.list().then(function (ports) {
-        var returnList = "";
-        ports.forEach(function (port) {
-            returnList += "<option>" + port.path + "</option>";
-        });
-        com_ports.innerHTML = returnList;
-        com_ports.value = current_port;
+        if(ports.length !== port_count) {
+            var returnList = "";
+            ports.forEach(function (port) {
+                returnList += "<option>" + port.path + "</option>";
+            });
+            com_ports.innerHTML = returnList;
+            com_ports.value = current_port;
+            port_count = ports.length;
+        }
+
     });
 }
 


### PR DESCRIPTION
Added a check for the amount of com ports found. Atleast in testing on mac, the list was getting updated every .5 seconds which was causing the drop down to disappear before a comport could be selected. 

I've done it very rudimentary, a cleaner way would be to do a deep compare on the array, however the chances of someone unplugging and plugging back in a different device within 0.5s is very small!