### PR TITLE
additional binary log file is created, when logging is enabled

### DIFF
--- a/src/main_window/preferences_handle.js
+++ b/src/main_window/preferences_handle.js
@@ -24,6 +24,7 @@ var hupcl_enable = document.getElementById("hupcl");
 const preferences_file_path = "./preferences.json";
 
 let log_file_writer = null;
+let bin_file_writer = null;
 var preferences = null;
 var prev_preferences = null;
 

--- a/src/main_window/renderer.js
+++ b/src/main_window/renderer.js
@@ -446,7 +446,7 @@ function recvData(payload) {
     runParsers();
 
     if (log_file_writer != null)
-        log_file_writer.write(message);
+        log_file_writer.write(payload);
     if (bin_file_writer != null)
         bin_file_writer.write(payload_raw);
      //terminal.innerHTML += message;


### PR DESCRIPTION
The received serial data is converted with toString(), which causes issues for binary data with bytes in the 128–255 range. To preserve the original binary data, an additional binary log file (log.bin) is now created.

In my use case (receiving binary data from an oscilloscope), negative values are misinterpreted as Unicode characters, corrupting the original binary data. To address this without impacting cases where this behavior might be intentional, I implemented a solution that preserves existing functionality. If reinterpreting serial data as Unicode was unintended, consider removing the old log file handling entirely.